### PR TITLE
Add auth and a function to sync a design doc.

### DIFF
--- a/cloudly/ccouchdb.py
+++ b/cloudly/ccouchdb.py
@@ -1,4 +1,5 @@
 import os
+import yaml
 
 import couchdb
 
@@ -9,13 +10,11 @@ log = logger.init(__name__)
 
 
 @Memoized
-def get_server(hostname=None, port=5984, username=None, password=None):
-    port = 5984
+def get_server(hostname=None, port=None, username=None, password=None):
     host = hostname or os.environ.get("COUCHDB_HOST", "127.0.0.1")
-    url = "http://{host}:{port}".format(
-        host=host,
-        port=port
-    )
+    port = port or os.environ.get("COUCHDB_PORT", 5984)
+    username = username or os.environ.get("COUCHDB_USERNAME", None)
+    password = password or os.environ.get("COUCHDB_PASSWORD", None)
 
     if username is not None and password is not None:
         url = "http://{username}:{password}@{host}:{port}".format(
@@ -24,6 +23,22 @@ def get_server(hostname=None, port=5984, username=None, password=None):
             username=username,
             password=password
         )
+    else:
+        url = "http://{host}:{port}".format(
+            host=host,
+            port=port
+        )
 
-    log.info("Connecting to CouchDB server at {}".format(url))
+    log.info("{} port {}".format(host, port))
     return couchdb.Server(url)
+
+
+def sync_design_doc(database, design_filename):
+    """Sync a design document written as a YAML file."""
+    with open(design_filename) as design_file:
+        design_doc = yaml.load(design_file)
+    # Delete old document, to avoid ResourceConflict exceptions.
+    old = database.get(design_doc['_id'])
+    if old:
+        database.delete(old)
+    database.save(design_doc)


### PR DESCRIPTION
With environment variables COUCHDB_USERNAME and COUCHDB_PASSWORD defined, will
connect as that user.

Now uses COUCHDB_PORT if defined.

Add a function to save a design document defined as a YAML file. Why YAML?
Because it's very easy to add Javascript code with syntax highlighting. Plus,
the general format is even lighter than other format like JSON.
