### PR TITLE
Add AWS EMR shell scripts for bootstraping a job.

### DIFF
--- a/cloudly/aws/emr/README.md
+++ b/cloudly/aws/emr/README.md
@@ -1,0 +1,35 @@
+Bootstraping an EMR jobflow
+===========================
+
+EMR instances run Debian 5.0 and are old. The best way to run our code (and the
+most predictable) is to compile python from source and build a virtualenv
+before launching a streaming job.
+
+You'll find scripts in here to help in doing so. Two archives will be created.
+The first will have a compiled python executable and associated libraries and
+the second will hold our virtualenv.
+
+The above is inspired from this [post](http://goo.gl/BS3uDl).
+
+binaries-build.sh
+-----------------
+
+This is the main script in which python is compiled and a virtualenv is
+created. This script will call another user-provided script called
+*venv-build.sh* in which your commands for installing python packages should
+be (e.g. `pip install` commands).
+
+bootstrap.sh
+------------
+
+This script is the bootstrap action given to Hadoop. It will fetch our two
+archives, install python and the virtualenv.
+
+
+jobrunner.sh
+------------
+
+Helper script to source a virtualenv before calling a python module. The first
+argument to this script should be a python module.  It will be called like so:
+
+    python -m myapp.mymodule

--- a/cloudly/aws/emr/bootstrap.sh
+++ b/cloudly/aws/emr/bootstrap.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+ 
+set -e 
+
+# Set your bucket name here.
+S3_BUCKET=YOUR_BUCKET_NAME
+
+ARCH=`uname -m`
+VENV=venv
+PYTHON_BINARIES=Python-2.7.binaries.$ARCH.tar.gz
+
+
+cd
+hadoop fs -get s3n://$S3_BUCKET/$PYTHON_BINARIES ./
+tar -xzf $PYTHON_BINARIES
+cd Python-2.7.3
+sudo make install
+ 
+curl http://python-distribute.org/distribute_setup.py | sudo python
+ 
+cd
+hadoop fs -get s3n://$S3_BUCKET/$VENV-virtualenv.binaries.$ARCH.tar.gz ~/
+tar -xzf $VENV-virtualenv.binaries.$ARCH.tar.gz
+
+echo "** Finished bootstraping."

--- a/cloudly/aws/emr/build-binaries.sh
+++ b/cloudly/aws/emr/build-binaries.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# This script is based on the instruction provided here: http://goo.gl/BS3uDl
+#
+# Its purpose is to build from source Python 2.7, build a relocatable
+# virtualenv and upload both to S3 for later bootstraping an EMR jobflow.
+#
+# You'll need two scripts for this:
+#
+# - bin-build.sh: this script.
+# - venv-build.sh: contains the instructions for building your customized
+#   virtualenv.
+#
+# The following scripts will be used to build the python binaries and
+# virtualenv and to install them on new nodes. 
+# 
+# - emr-venv-build.sh: the master script. This should be executed on a typical
+#   EMR node into which you ssh'ed.
+# - emr-venv-bootstrap.sh: the script to be run whenever you start a new EMR
+#   jobflow.
+
+
+set -e
+
+# Set your bucket name here. This will receive the two archives created below.
+S3_BUCKET=YOUR_BUCKET_NAME
+
+ARCH=`uname -m`
+VENV=venv
+
+# Install python 2.7 with SSL support
+starttime=`date +%s`
+sudo apt-get install libssl-dev
+cd
+wget http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
+tar -xzf Python-2.7.3.tgz
+cd Python-2.7.3
+sudo ./configure --enable-shared --prefix=/usr
+sudo make && sudo make install
+
+python --version
+echo "** Installed python in $((`date +%s` - $starttime)) sec"
+
+starttime=`date +%s`
+# Installed updated version of setuptools
+curl http://python-distribute.org/distribute_setup.py | sudo python
+# Install virtualenv
+sudo easy_install virtualenv
+
+cd
+virtualenv $VENV
+source $VENV/bin/activate
+
+# The following script is specific to your virtualenv.
+source venv-build.sh
+
+echo "** Installed python libraries in $((`date +%s` - $starttime)) sec"
+
+# Make the virtualenv relocatable, this isn't strictly necessary I think.
+# virtualenv is all you need as long as you always deploy it to the right place
+virtualenv --relocatable $VENV
+
+# Zip up tarballs and send them to s3
+tar -czf Python-2.7.binaries.$ARCH.tar.gz Python-2.7.3
+hadoop fs -put Python-2.7.binaries.$ARCH.tar.gz s3n://$S3_BUCKET/Python-2.7.binaries.$ARCH.tar.gz
+tar -czf $VENV-virtualenv.binaries.$ARCH.tar.gz $VENV
+hadoop fs -put $VENV-virtualenv.binaries.$ARCH.tar.gz s3n://$S3_BUCKET/$VENV-virtualenv.binaries.$ARCH.tar.gz

--- a/cloudly/aws/emr/jobrunner.sh
+++ b/cloudly/aws/emr/jobrunner.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+HOME=/home/hadoop
+VENV=venv
+
+source $HOME/$VENV/bin/activate
+python -m $1


### PR DESCRIPTION
These are helper scripts to bootstrap a virtualenv using Python 2.7.
