### PR TITLE
Version 0.5.0.

### DIFF
--- a/cloudly/__init__.py
+++ b/cloudly/__init__.py
@@ -1,6 +1,6 @@
 __title__ = "cloudly"
 __title__ = 'A helper library for everything cloud.'
-__version__ = "4.0.0"
+__version__ = "0.5.0"
 __author__ = "Hugues Demers"
 __email__ = "hugues.demers@ooda.ca"
 __license__ = "MIT"


### PR DESCRIPTION
I should not have moved to 1.0.0. It's just confusing to bump the major version
number each time because it's not backward compatible. Cloudly is still very
much in development.
