### PR TITLE
Easily deploy Salt minions.

### DIFF
--- a/bin/minion
+++ b/bin/minion
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
 """
-SALT_MASTER_HOSTNAME or hostname
-EC2_AMI_ID
-EC2_INSTANCE_TYPE
-EC2_SECURITY_GROUP
-USER
+Launch one or more EC2 instances, install the Salt Stack minion daemon and
+optionally execute a Salt state. The AMI ID can be specified on the
+command-line, if not will be taken from the environment variable EC2_AMI_ID.
+The default security group is DEFAULT_SECURITY_GROUP and the default instance
+type is DEFAULT_INSTANCE_TYPE.
 
+The Salt master hostname is the server hostname on we're running or if defined
+the environment variable SALT_MASTER_HOSTNAME.
 """
 import argparse
 import os
 import platform
+from time import sleep
 
 from termcolor import colored
 
@@ -17,11 +20,24 @@ from cloudly import minion
 from cloudly.aws import ec2
 
 
+DEFAULT_SECURITY_GROUP = "default"
+DEFAULT_INSTANCE_TYPE = "m1.small"
+
+
 def parse():
-    parser = argparse.ArgumentParser()
+    description = """
+    Launch one or more EC2 instances, install the Salt Stack minion daemon and
+    optionally execute a Salt state. The AMI ID can be specified on the
+    command-line, if not will be taken from the environment variable
+    EC2_AMI_ID. The default security group is '{}' and the default instance
+    type is '{}'. The Salt master hostname is the server hostname we're
+    running on or if defined the environment variable SALT_MASTER_HOSTNAME.
+    """.format(DEFAULT_SECURITY_GROUP, DEFAULT_INSTANCE_TYPE)
+
+    parser = argparse.ArgumentParser(description=description)
 
     parser.add_argument("action",
-                        choices=['launch', 'terminate', 'ssh', 'reboot'],
+                        choices=['launch', 'terminate', 'reboot'],
                         help="action to perform")
 
     parser.add_argument("-p", "--id-postfix", help="minion's id postfix")
@@ -32,22 +48,33 @@ def parse():
     parser.add_argument("-t", "--instance-type",
                         help="the instance type to launch")
 
-    parser.add_argument("-s", "--security-group",
+    parser.add_argument("-g", "--security-group",
                         help="the security group to launch under")
+
+    parser.add_argument("-s", "--state",
+                        help="the Salt state to execute")
+
+    parser.add_argument("-e", "--env", default="dev",
+                        help="the Salt environment, e.g. prod, dev")
+
     return parser.parse_args()
 
 
-def launch(minion_id_postfix, ami_id, instance_type, security_group):
+def launch(minion_id_postfix, ami_id, instance_type, security_group,
+           salt_state=None, salt_env=None):
     master_hostname = os.environ.get("SALT_MASTER_HOSTNAME", platform.node())
 
     ami_id = ami_id or os.environ.get("EC2_AMI_ID")
     security_group = security_group or os.environ.get("EC2_SECURITY_GROUP",
-                                                      "default")
+                                                      DEFAULT_SECURITY_GROUP)
     instance_type = instance_type or os.environ.get("EC2_INSTANCE_TYPE",
-                                                    'm1.small')
+                                                    DEFAULT_INSTANCE_TYPE)
     print(colored(
         "Lauching 1 instance {} of type {} with security group {!r}.".format(
             ami_id, instance_type, security_group), 'yellow'))
+    if salt_state:
+        print(colored("Will execute Salt state '{}' within '{}' env".format(
+            salt_state, salt_env), 'yellow'))
 
     instances = minion.launch(master_hostname, minion_id_postfix,
                               ami_id=ami_id,
@@ -60,6 +87,15 @@ def launch(minion_id_postfix, ami_id, instance_type, security_group):
     print(colored("Instance running and ready at '{}'.".format(
         instance.public_dns_name), 'yellow'))
     print(colored("Minion id is '{}'".format(minion_id), 'yellow'))
+
+    if salt_state:
+        # This wait period seems necessary before salt-minion becomes
+        # responsive.
+        sleep(30)
+        print(colored("Executing Salt state '{}'".format(salt_state),
+                      'yellow'))
+        print(minion.salt_state(salt_state, minion_id, salt_env))
+    print("done.")
 
 
 def choose_minion():
@@ -93,6 +129,6 @@ if __name__ == '__main__':
 
     if args.action == 'launch':
         launch(args.id_postfix, args.ami_id, args.instance_type,
-               args.security_group)
+               args.security_group, args.state, args.env)
     elif args.action == 'terminate':
         terminate()

--- a/bin/minion
+++ b/bin/minion
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+SALT_MASTER_HOSTNAME or hostname
+EC2_AMI_ID
+EC2_INSTANCE_TYPE
+EC2_SECURITY_GROUP
+USER
+
+"""
+import argparse
+import os
+import platform
+
+from termcolor import colored
+
+from cloudly import minion
+from cloudly.aws import ec2
+
+
+def parse():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("action",
+                        choices=['launch', 'terminate', 'ssh', 'reboot'],
+                        help="action to perform")
+
+    parser.add_argument("-p", "--id-postfix", help="minion's id postfix")
+
+    parser.add_argument("-a", "--ami-id",
+                        help="the AMI id to launch")
+
+    parser.add_argument("-t", "--instance-type",
+                        help="the instance type to launch")
+
+    parser.add_argument("-s", "--security-group",
+                        help="the security group to launch under")
+    return parser.parse_args()
+
+
+def launch(minion_id_postfix, ami_id, instance_type, security_group):
+    master_hostname = os.environ.get("SALT_MASTER_HOSTNAME", platform.node())
+
+    ami_id = ami_id or os.environ.get("EC2_AMI_ID")
+    security_group = security_group or os.environ.get("EC2_SECURITY_GROUP",
+                                                      "default")
+    instance_type = instance_type or os.environ.get("EC2_INSTANCE_TYPE",
+                                                    'm1.small')
+    print(colored(
+        "Lauching 1 instance {} of type {} with security group {!r}.".format(
+            ami_id, instance_type, security_group), 'yellow'))
+
+    instances = minion.launch(master_hostname, minion_id_postfix,
+                              ami_id=ami_id,
+                              instance_type=instance_type,
+                              security_group="default")
+
+    instance = instances[0]
+    minion_id = instance.tags['minion_id']
+
+    print(colored("Instance running and ready at '{}'.".format(
+        instance.public_dns_name), 'yellow'))
+    print(colored("Minion id is '{}'".format(minion_id), 'yellow'))
+
+
+def choose_minion():
+    instances = ec2.all()
+    if len(instances) == 1:
+        return instances[0]
+
+    minion.print_minions(instances)
+    index = raw_input("\nChoose AMI instance (None): ")
+    instance = None
+    if index.isdigit() and int(index) < len(instances):
+        instance = instances[int(index)]
+    return instance
+
+
+def terminate():
+    instance = choose_minion()
+    minion.terminate(instance)
+    name = instance.tags.get('Name')
+    if name:
+        msg = colored("Instance {} ({}) will be terminated.".format(
+            name, instance.id), 'red')
+    else:
+        msg = colored("Instance {} will be terminated.".format(
+            instance.id), 'red')
+    print(msg)
+
+
+if __name__ == '__main__':
+    args = parse()
+
+    if args.action == 'launch':
+        launch(args.id_postfix, args.ami_id, args.instance_type,
+               args.security_group)
+    elif args.action == 'terminate':
+        terminate()

--- a/cloudly/aws/ec2.py
+++ b/cloudly/aws/ec2.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import itertools
 import urllib
 
@@ -222,3 +223,32 @@ def launch(ami_id=None, instance_type=None,
                                            security_groups=[security_group],
                                            user_data=user_data)
     return reservation.instances
+
+
+def print_instances(instances, show_terminated=False):
+    """Print out list of hosts. Set only_running to false
+    to also print out turned off machines."""
+    for index, instance in enumerate(instances):
+        if instance.state == "running" or show_terminated:
+            sys.stdout.write(("{index:>4}: {name:<20} "
+                              "{instance.ip_address:<16} "
+                              "{launch_time:<12} {instance.id:<12} "
+                              "{instance.image_id:<13}\n").format(
+                                  index=index,
+                                  instance=instance,
+                                  launch_time=instance.launch_time[:10],
+                                  name=instance.tags.get("Name", "no name")
+                              ))
+
+
+def choose_instance():
+    instances = all()
+    if len(instances) == 1:
+        return instances[0]
+
+    print_instances(instances)
+    index = raw_input("\nChoose AMI instance (None): ")
+    instance = None
+    if index.isdigit() and int(index) < len(instances):
+        instance = instances[int(index)]
+    return instance

--- a/cloudly/minion.py
+++ b/cloudly/minion.py
@@ -1,0 +1,136 @@
+"""Ease deployment of applications with Salt Stack.
+
+Cf. http://docs.saltstack.com
+
+"""
+from time import sleep
+from subprocess import check_output
+import json
+import sys
+
+from cloudly.aws import ec2
+
+SALT_BOOTSTRAP_SCRIPT = """#!/bin/bash
+
+# Install saltstack
+add-apt-repository ppa:saltstack/salt -y
+apt-get update -y
+apt-get install salt-minion -y
+apt-get upgrade -y
+
+HOSTNAME=`hostname`
+
+# Set salt master location and start minion
+sed -i "s/#master: salt/master: {master_hostname}/" /etc/salt/minion
+sed -i "s/#id:/id: $HOSTNAME-{minion_id_postfix}/" /etc/salt/minion
+restart salt-minion
+"""
+
+
+def launch(master_hostname, minion_id_postfix, ami_id=None, instance_type=None,
+           security_group=None, count=1, key_name=None):
+    """Launch an EC2 AMI instance and bootstrap Salt Stack.
+    This function:
+        - launch one or more EC2 AMI instances;
+        - bootstrap a Salt minion on each;
+        - wait for all minions to contact the master;
+        - accept all minions' keys.
+
+    WARNING: all instances will have the same postfix `minion-id`
+
+    cf. http://docs.saltstack.com/topics/tutorials/bootstrap_ec2.html
+    """
+    user_data = SALT_BOOTSTRAP_SCRIPT.format(
+        master_hostname=master_hostname, minion_id_postfix=minion_id_postfix)
+
+    instances = ec2.launch(ami_id=ami_id, instance_type=instance_type,
+                           security_group=security_group, key_name=key_name,
+                           user_data=user_data, count=count)
+
+    ready = False
+    while not ready:
+        sleep(3)
+        keys = jshell("/usr/bin/salt-key -L --out json")
+        [instance.update() for instance in instances]
+        minion_ids = [get_minion_id(i, minion_id_postfix) for i in instances]
+        ready = all([minion_id in keys['minions_pre']
+                     for minion_id in minion_ids])
+
+    for key in minion_ids:
+        shell("/usr/bin/salt-key -ya {}".format(key))
+
+    for instance in instances:
+        instance.add_tag("minion_id", get_minion_id(instance,
+                                                    minion_id_postfix))
+    return instances
+
+
+def reboot(instances):
+    for instance in instances:
+        instance.reboot()
+
+    sleep(5)
+    ready = False
+    cmd = "/usr/bin/salt '{}' test.ping --out json"
+    while not ready:
+        results = []
+        for instance in instances:
+            minion_id = instance.tags['minion_id']
+            result = shell(cmd.format(minion_id))
+            if result:
+                running = json.loads(result)[minion_id]
+            else:
+                running = False
+            results.append(running)
+        ready = all(results)
+
+
+def salt_state(state, minion_id):
+    return shell("/usr/bin/salt '{}' state.sls {}".format(minion_id, state))
+
+
+def salt(cmd, minion):
+    return jshell("/usr/bin/salt '{}' {}".format(minion, cmd))
+
+
+def jshell(cmd):
+    return json.loads(shell(cmd))
+
+
+def shell(cmd):
+    return check_output(cmd, shell=True)
+
+
+def pip_upgrade(pkg, minions="*", venv=".virtualenv"):
+    shell("salt '{}' pip.install {} upgrade=True bin_env={}".format(
+        minions, pkg, venv))
+
+
+def get_minion_id(instance, minion_id_postfix):
+    return "{}-{}".format(instance.private_dns_name.split('.')[0],
+                          minion_id_postfix)
+
+
+def print_minions(instances, show_terminated=False):
+    """Print out list of hosts. Set only_running to false
+    to also print out turned off machines."""
+    for index, instance in enumerate(instances):
+        minion_id = instance.tags.get('minion_id')
+        if instance.state == "running" and minion_id:
+            sys.stdout.write(("{index:>4}: {name:<20} "
+                              "{instance.ip_address:<16} "
+                              "{launch_time:<12} {instance.id:<12} "
+                              "{instance.image_id:<13} {minion_id:<15}"
+                              "\n").format(
+                                  minion_id=minion_id,
+                                  index=index,
+                                  instance=instance,
+                                  launch_time=instance.launch_time[:10],
+                                  name=instance.tags.get("Name", "no name"),
+                              ))
+
+
+def terminate(instance):
+    minion_id = instance.tags['minion_id']
+    shell("/usr/bin/salt-key -yd {}".format(minion_id))
+    instance.terminate()

--- a/cloudly/minion.py
+++ b/cloudly/minion.py
@@ -85,11 +85,13 @@ def reboot(instances):
         ready = all(results)
 
 
-def salt_state(state, minion_id):
-    return shell("/usr/bin/salt '{}' state.sls {}".format(minion_id, state))
+def salt_state(state, minion_id, env):
+    # TODO: Salt returns an error code 0 even when it errors out. Bummer.
+    return shell("/usr/bin/salt {} state.sls {} {}".format(minion_id, state,
+                                                           env))
 
 
-def salt(cmd, minion):
+def salt_cmd(cmd, minion):
     return jshell("/usr/bin/salt '{}' {}".format(minion, cmd))
 
 
@@ -98,6 +100,8 @@ def jshell(cmd):
 
 
 def shell(cmd):
+    # Note: shell=True is necessary for salt commands to be executed as the
+    # authorized user. See the *user* option in /etc/salt/master.
     return check_output(cmd, shell=True)
 
 

--- a/cloudly/pubsub.py
+++ b/cloudly/pubsub.py
@@ -14,9 +14,8 @@ from cloudly.decorators import Memoized
 
 class Pubsub(object):
     """Encapsulate a connection to pubsub service provider.
-    An instance of this class should be bound to a specific channel. If no
-    credential are provided at initialization, they shall be taken from the
-    environment.
+    If no credential are provided at initialization, they shall be taken from
+    the environment.
     """
 
     def __init__(self, channel):
@@ -25,11 +24,6 @@ class Pubsub(object):
 
     def publish(self, message, event):
         raise NotImplementedError("Use a subclass of this one.")
-
-    @classmethod
-    def open(cls):
-        """Return an instance of this class with provided credentials."""
-        raise NotImplementedError
 
 
 class Pusher(Pubsub):
@@ -40,30 +34,30 @@ class Pusher(Pubsub):
     """
 
     provider_name = "pusher"
-    client_key = None
 
-    def __init__(self, channel):
+    def __init__(self, channel, app_id=None, key=None, secret=None):
+        if not (app_id and key and secret):
+            app_id = os.environ.get("PUSHER_APP_ID")
+            key = os.environ.get("PUSHER_KEY")
+            secret = os.environ.get("PUSHER_SECRET")
+        self.app_id = app_id
+        self.key = key
+        self.secret = secret
         super(Pusher, self).__init__(channel)
 
     def publish(self, message, event):
         if not message:
             return
 
+        if not self.pubsub:
+            self.pubsub = self._connect(self.app_id, self.key, self.secret)
+
         self.pubsub[self.channel].trigger(event, message)
 
     @classmethod
     @Memoized
-    def open(cls, channel, app_id=None, key=None, secret=None):
-        if not (app_id and key and secret):
-            app_id = os.environ.get("PUSHER_APP_ID")
-            key = os.environ.get("PUSHER_KEY")
-            secret = os.environ.get("PUSHER_SECRET")
-
-        obj = cls(channel)
-        obj.pubsub = pusher.Pusher(app_id=app_id, key=key, secret=secret)
-
-        cls.client_key = key
-        return obj
+    def _connect(cls, app_id, key, secret):
+        return pusher.Pusher(app_id=app_id, key=key, secret=secret)
 
 
 class Pubnub(Pubsub):
@@ -75,13 +69,27 @@ class Pubnub(Pubsub):
 
     provider_name = "pubnub"
 
-    def __init__(self, channel):
+    def __init__(self, channel, publish_key=None, subscribe_key=None,
+                 secret_key=None):
+        if not (publish_key and subscribe_key):
+            publish_key = os.environ.get("PUBNUB_PUBLISH_KEY")
+            subscribe_key = os.environ.get("PUBNUB_SUBSCRIBE_KEY")
+            secret_key = os.environ.get("PUBNUB_SECRET_KEY")
+
+        self.publish_key = publish_key
+        self.subscribe_key = subscribe_key
+        self.secret_key = secret_key
+
         super(Pubnub, self).__init__(channel)
 
     def publish(self, message, event=None):
         """Parameter event is not used by Pubnub"""
         if not message:
             return
+
+        if not self.pubsub:
+            self.pubsub = self._connect(self.publish_key, self.subscribe_key,
+                                        self.secret_key)
 
         result = self.pubsub.publish({
             'channel': self.channel,
@@ -93,15 +101,6 @@ class Pubnub(Pubsub):
 
     @classmethod
     @Memoized
-    def open(cls, channel, publish_key=None, subscribe_key=None,
-             secret_key=None, ssl_on=False):
-
-        if not (publish_key and subscribe_key):
-            publish_key = os.environ.get("PUBNUB_PUBLISH_KEY")
-            subscribe_key = os.environ.get("PUBNUB_SUBSCRIBE_KEY")
-            secret_key = os.environ.get("PUBNUB_SECRET_KEY")
-
-        obj = cls(channel)
-        obj.pubsub = pubnub.Pubnub(publish_key, subscribe_key,
-                                   secret_key=secret_key, ssl_on=ssl_on)
-        return obj
+    def _connect(cls, publish_key, subscribe_key, secret_key, ssl_on=False):
+        return pubnub.Pubnub(publish_key, subscribe_key,
+                             secret_key=secret_key, ssl_on=ssl_on)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ rq==0.3.7
 couchdb==0.8
 python-memcached==1.48
 isodate==0.4.9
-cuisine==0.5.6
 pusher==0.7
 twitter==1.9.4
 pubnub==3.3.1
 pyyaml==3.10
+termcolor==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url='https://github.com/ooda/cloudly',
     license=__license__,
     packages=find_packages(exclude=('tests', 'docs')),
-    scripts=['bin/sshaws', 'bin/launch', 'bin/s3get'],
+    scripts=['bin/sshaws', 'bin/launch', 'bin/s3get', 'bin/minion'],
     install_requires=[
         'boto',
         'redis',
@@ -22,10 +22,10 @@ setup(
         'couchdb',
         'python-memcached',
         'isodate',
-        'cuisine',
         'pusher',
         'twitter',
         'pubnub',
-        'pyyaml'
+        'pyyaml',
+        'termcolor'
     ]
 )

--- a/tests/unittests/cloudly/test_pubsub.py
+++ b/tests/unittests/cloudly/test_pubsub.py
@@ -2,10 +2,10 @@ from cloudly import pubsub
 
 
 def test_pusher():
-    provider = pubsub.Pusher.open("test")
+    provider = pubsub.Pusher("test")
     provider.publish("test", "event")
 
 
 def test_pubnub():
-    provider = pubsub.Pubnub.open("test")
+    provider = pubsub.Pubnub("test")
     provider.publish("test")


### PR DESCRIPTION
- Deployment scripts for salt stack.
- Lazy pubsub connections.
  Don't connect to a pubsub service until we try to publish something.
- Execute a Salt state after minion starts.
