### PR TITLE
Fix Twitter streaming API changes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ couchdb==0.8
 python-memcached==1.48
 isodate==0.4.9
 pusher==0.7
-twitter==1.9.4
+git+https://github.com/adonoho/twitter.git@pr-fix-stream#egg=twitter
 pubnub==3.3.1
 pyyaml==3.10
 termcolor==1.1.0


### PR DESCRIPTION
Twitter has moved all of its streaming APIs to HTTP 1.1 chunked encoded
transfer and broke the python library we use. This change fixes this. We use a
branch from a user who fixed the library, but the change has not been ported
back into it. The main developer is not responding and it seems we're looking
at a fork of this code going forward.
